### PR TITLE
fix: update GitHub Actions checkout and cache actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       PYTHONPATH: .
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -30,7 +30,7 @@ jobs:
 
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}


### PR DESCRIPTION
## Summary by Sourcery

Update CI workflow to use the latest major versions of checkout and cache GitHub Actions.

CI:
- Bump actions/checkout from v4 to v6 in the CI workflow.
- Bump actions/cache from v4 to v5 for Python virtualenv caching in the CI workflow.