### PR TITLE
update main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       PYTHONPATH: .
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -30,7 +30,7 @@ jobs:
 
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}


### PR DESCRIPTION
- update gh actions

## Summary by Sourcery

Update CI workflow to use the latest versions of GitHub checkout and cache actions.

CI:
- Bump actions/checkout from v4 to v6 in the CI workflow.
- Bump actions/cache from v4 to v5 in the CI workflow.