### PR TITLE
feat: add djangocms-versioning i18n support to test env

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -99,6 +99,25 @@ files = [
 Django = ">=3.2"
 
 [[package]]
+name = "django-fsm-2"
+version = "4.2.2"
+description = "Django friendly finite state machine support."
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "django_fsm_2-4.2.2-py3-none-any.whl", hash = "sha256:d5fd0724d82834e3643ef6cae7e06c169533ccfdd5c4098d88e3fd9af0eba4f1"},
+    {file = "django_fsm_2-4.2.2.tar.gz", hash = "sha256:0d03f3916d535867dfe56cbfd505f63e41c026403c27c4969b83605cd08ad863"},
+]
+
+[package.dependencies]
+django = ">=4.2.29"
+django-stubs-ext = "*"
+typing-extensions = {version = "*", markers = "python_version < \"3.12\""}
+
+[package.extras]
+graphviz = ["graphviz"]
+
+[[package]]
 name = "django-parler"
 version = "2.3"
 description = "Simple Django model translations without nasty hacks, featuring nice admin integration."
@@ -126,6 +145,21 @@ files = [
 [package.dependencies]
 django = ">=3.2"
 django-classy-tags = ">=3.0"
+
+[[package]]
+name = "django-stubs-ext"
+version = "5.2.9"
+description = "Monkey-patching and extensions for django-stubs"
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "django_stubs_ext-5.2.9-py3-none-any.whl", hash = "sha256:230c51575551b0165be40177f0f6805f1e3ebf799b835c85f5d64c371ca6cf71"},
+    {file = "django_stubs_ext-5.2.9.tar.gz", hash = "sha256:6db4054d1580657b979b7d391474719f1a978773e66c7070a5e246cd445a25a9"},
+]
+
+[package.dependencies]
+django = "*"
+typing-extensions = "*"
 
 [[package]]
 name = "django-treebeard"
@@ -171,6 +205,22 @@ files = [
 
 [package.dependencies]
 Django = "*"
+
+[[package]]
+name = "djangocms-versioning"
+version = "2.5.1"
+description = "Versioning for django CMS"
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "djangocms_versioning-2.5.1-py3-none-any.whl", hash = "sha256:f396014400dab3a561227d5395496aec40666f5e36aa8337f99aff8752249581"},
+    {file = "djangocms_versioning-2.5.1.tar.gz", hash = "sha256:8e4d69e583918a8bb6264049a865c68abd2adc8cd14aa150b8ab1ad4d852a226"},
+]
+
+[package.dependencies]
+django-cms = ">=4.1.1"
+django-fsm-2 = "*"
+packaging = "*"
 
 [[package]]
 name = "iniconfig"
@@ -353,6 +403,17 @@ dev = ["build"]
 doc = ["sphinx"]
 
 [[package]]
+name = "typing-extensions"
+version = "4.15.0"
+description = "Backported and Experimental Type Hints for Python 3.9+"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
+    {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
+]
+
+[[package]]
 name = "tzdata"
 version = "2025.3"
 description = "Provider of IANA time zone data"
@@ -366,4 +427,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<4.0"
-content-hash = "600ec1cd16e5b867a106ff6018482ce5c01ed17dc1fb3e84cf2ae6af2695fd49"
+content-hash = "80f02de525eaef9b6690fa66552bfac8b61887e209c76cae0c0a8edefb2e7f69"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ django-cms = "5.0.3"
 django-treebeard = "<5.0"
 django-parler = "~2.3"
 django-unfold = ">=0.77.1"
+djangocms-versioning = "^2.5.1"
 
 [tool.poetry.group.test.dependencies]
 pytest = ">=8.0"

--- a/tests/server/testapp/settings.py
+++ b/tests/server/testapp/settings.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from django.core.management.utils import get_random_secret_key
 from django.templatetags.static import static
+from django.utils.translation import gettext_lazy as _
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -13,6 +14,7 @@ DEBUG = True
 ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
 
 USE_TZ = True
+USE_I18N = True
 
 INSTALLED_APPS = [
     # Unfold must come before django.contrib.admin
@@ -36,7 +38,8 @@ INSTALLED_APPS = [
     "menus",
     "treebeard",
     "sekizai",
-    # Django CMS plugins
+    # Django CMS versioning
+    "djangocms_versioning",
     # Parler
     "parler",
     # Test app
@@ -44,15 +47,15 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "cms.middleware.utils.ApphookReloadMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "django.middleware.locale.LocaleMiddleware",
-    "cms.middleware.utils.ApphookReloadMiddleware",
     "cms.middleware.user.CurrentUserMiddleware",
     "cms.middleware.page.CurrentPageMiddleware",
     "cms.middleware.toolbar.ToolbarMiddleware",
@@ -72,6 +75,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "django.template.context_processors.i18n",
                 "sekizai.context_processors.sekizai",
                 "cms.context_processors.cms_settings",
             ],
@@ -93,20 +97,37 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 # Django sites framework
 SITE_ID = 1
 
-# Django CMS settings
-CMS_TEMPLATES = [
-    ("base.html", "Base"),
-]
-
-CMS_CONFIRM_VERSION4 = True
-CMS_PERMISSION = False
-CMS_COLOR_SCHEME_TOGGLE = False
+# --- Language / i18n ---
+LANGUAGE_CODE = "en"
 
 LANGUAGES = [
-    ("en", "English"),
-    ("de", "German"),
+    ("en", _("English")),
+    ("de", _("German")),
 ]
-LANGUAGE_CODE = "en"
+
+# CMS language configuration (keyed by SITE_ID)
+# https://docs.django-cms.org/en/latest/topics/i18n.html
+CMS_LANGUAGES = {
+    SITE_ID: [
+        {
+            "code": "en",
+            "name": _("English"),
+            "public": True,
+        },
+        {
+            "code": "de",
+            "name": _("Deutsch"),
+            "public": True,
+            "hide_untranslated": True,
+        },
+    ],
+    "default": {
+        "fallbacks": ["en"],
+        "redirect_on_fallback": True,
+        "public": True,
+        "hide_untranslated": False,
+    },
+}
 
 # Parler settings
 PARLER_LANGUAGES = {
@@ -120,8 +141,21 @@ PARLER_LANGUAGES = {
     },
 }
 
-# Unfold settings
+# --- Django CMS ---
+CMS_TEMPLATES = [
+    ("base.html", "Base"),
+]
+
+CMS_CONFIRM_VERSION4 = True
+CMS_PERMISSION = False
+CMS_COLOR_SCHEME_TOGGLE = False
+
+# djangocms-versioning: default user for programmatic version creation (tests/fixtures)
+DJANGOCMS_VERSIONING_DEFAULT_USER = 1
+
+# --- Unfold ---
 UNFOLD = {
+    "SHOW_LANGUAGES": True,
     "STYLES": [
         lambda request: static("unfold_extra/css/styles.css"),
     ],

--- a/tests/server/testapp/urls.py
+++ b/tests/server/testapp/urls.py
@@ -1,7 +1,13 @@
+from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin
 from django.urls import include, path
 
 urlpatterns = [
+    path("i18n/", include("django.conf.urls.i18n")),
+]
+
+urlpatterns += i18n_patterns(
     path("admin/", admin.site.urls),
     path("", include("cms.urls")),
-]
+    prefix_default_language=False,
+)


### PR DESCRIPTION
## Summary by Sourcery

Add multilingual and djangocms-versioning support to the Django test app environment.

New Features:
- Enable Django and Django CMS internationalization in the test app, including language configuration and i18n URL patterns.
- Integrate djangocms-versioning into the test app with a default user for programmatic version creation.

Enhancements:
- Adjust middleware and context processors ordering to support locale handling and CMS apphook reloading.
- Expose language switching in the Unfold admin configuration.
- Declare djangocms-versioning as a project dependency in pyproject configuration.