### PR TITLE
feat: add inline-safe variant of PageSelectWidget to handle cloned rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,28 @@ See Unfold docs:
 - https://unfoldadmin.com/docs/configuration/modeladmin/
 - https://unfoldadmin.com/docs/tabs/fieldsets/
 
+### Page Select Widget
+
+Unfold-styled replacements for django CMS's `PageSelectWidget`:
+
+- `UnfoldPageSelectWidget` — use in regular admin forms and CMS plugin forms.
+- `UnfoldPageSelectInlineWidget` — use in Django admin inlines. Django admin's
+  inline cloning leaves `__prefix__` inside the widget's JSON config; this
+  variant ships a small JS patch so the site/page change handler binds to
+  dynamically added rows.
+
+```python
+from cms.forms.fields import PageSelectFormField
+from unfold_extra.contrib.cms.widgets import (
+    UnfoldPageSelectInlineWidget,
+    UnfoldPageSelectWidget,
+)
+
+
+class MyInlineForm(forms.ModelForm):
+    page = PageSelectFormField(widget=UnfoldPageSelectInlineWidget())
+```
+
 ### Frontend django CMS Support
 
 Add `unfold_extra_tags` to your base HTML template after loading all CSS styles.

--- a/unfold_extra/contrib/cms/widgets.py
+++ b/unfold_extra/contrib/cms/widgets.py
@@ -18,3 +18,10 @@ class UnfoldPageSelectWidget(PageSelectWidget):
             UnfoldAdminSelectWidget(choices=[("", "----")]),
             UnfoldAdminSelectWidget(choices=self.choices),
         )
+
+
+class UnfoldPageSelectInlineWidget(UnfoldPageSelectWidget):
+    """Inline-safe variant: patches the ``__prefix__`` bug in cloned rows."""
+
+    class Media:
+        js = ("unfold_extra/cms/js/pageselect_inline.js",)

--- a/unfold_extra/static/unfold_extra/cms/js/pageselect_inline.js
+++ b/unfold_extra/static/unfold_extra/cms/js/pageselect_inline.js
@@ -1,0 +1,104 @@
+(function () {
+  "use strict";
+
+  var cmsSiteReloadPending = false;
+
+  function deriveWidgetName(widget) {
+    // Django admin rewrites `__prefix__` in id/name attributes but leaves the
+    // JSON inside `<script type="application/json">` untouched. Read the real
+    // name back from the first sibling <select> so PageSelectWidget can find
+    // the dynamically inserted inline row's elements.
+    var container = widget.previousElementSibling;
+    if (!container) {
+      return null;
+    }
+    var siteSelect = container.querySelector("select[id$='_0']");
+    if (!siteSelect || !siteSelect.id) {
+      return null;
+    }
+    return siteSelect.id.replace(/^id_/, "").replace(/_0$/, "");
+  }
+
+  function initPageSelectWidgets(root) {
+    if (!window.CMS || !window.CMS.PageSelectWidget || !root) {
+      return;
+    }
+
+    var widgets = root.querySelectorAll("[data-cms-widget-pageselect]");
+    widgets.forEach(function (widget) {
+      if (widget.dataset.cmsPageselectInlineInit === "1") {
+        return;
+      }
+
+      var script = widget.querySelector("script");
+      if (!script) {
+        return;
+      }
+
+      try {
+        var config = JSON.parse(script.textContent || "{}");
+        var actualName = deriveWidgetName(widget);
+        if (actualName) {
+          config.name = actualName;
+        }
+        new window.CMS.PageSelectWidget(config);
+        widget.dataset.cmsPageselectInlineInit = "1";
+      } catch (error) {
+        // Keep admin usable even if one inline payload is malformed.
+      }
+    });
+  }
+
+  document.addEventListener("formset:added", function (event) {
+    if (event.target instanceof Element) {
+      initPageSelectWidgets(event.target);
+    }
+  });
+
+  function requestReloadAfterSiteSwitch() {
+    if (cmsSiteReloadPending) {
+      return;
+    }
+
+    cmsSiteReloadPending = true;
+    // Wait until CMS has persisted the selected admin site in session.
+    window.setTimeout(function () {
+      window.location.reload();
+    }, 150);
+  }
+
+  function isCmsSiteSwitchHref(href) {
+    if (!href) {
+      return false;
+    }
+
+    return (
+      href.indexOf("cms_admin_site") !== -1 ||
+      (href.indexOf("/admin/cms/") !== -1 && href.indexOf("site") !== -1)
+    );
+  }
+
+  document.addEventListener("click", function (event) {
+    var link = event.target && event.target.closest ? event.target.closest("a") : null;
+    if (!link) {
+      return;
+    }
+
+    if (isCmsSiteSwitchHref(link.getAttribute("href") || "")) {
+      requestReloadAfterSiteSwitch();
+    }
+  });
+
+  document.addEventListener("change", function (event) {
+    var target = event.target;
+    if (!(target instanceof HTMLSelectElement)) {
+      return;
+    }
+
+    var id = target.id || "";
+    var name = target.name || "";
+    if (id.indexOf("site") !== -1 || name.indexOf("site") !== -1) {
+      requestReloadAfterSiteSwitch();
+    }
+  });
+})();


### PR DESCRIPTION
## Summary by Sourcery

Introduce an inline-safe variant of the django CMS PageSelect widget and document its usage.

New Features:
- Add UnfoldPageSelectInlineWidget for use in Django admin inlines with django CMS PageSelectField widgets.

Enhancements:
- Add frontend JavaScript helper to correctly initialize PageSelect widgets in dynamically added inlines and keep site switch handling working.

Documentation:
- Document the Unfold-styled Page Select widgets and provide usage examples for regular forms and admin inlines.