### PR TITLE
fix cms modal breadcrumb style

### DIFF
--- a/unfold_extra/src/css/unfold_extra.css
+++ b/unfold_extra/src/css/unfold_extra.css
@@ -212,13 +212,6 @@ body.cms-admin-sideframe #changelist-filter {
 }
 
 /*******************************************************
- django-cms - modal breadcrumbs
- *******************************************************/
-div.cms .cms-modal-breadcrumb {
-    @apply py-4
-}
-
-/*******************************************************
  django-cms - pagetree
  *******************************************************/
 .cms-pagetree-root {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Resolve incorrect or undesired padding on django CMS modal breadcrumbs by removing the extra CSS rule.