### PR TITLE
cms modal border removed + text editor toolbar style issue fixed

### DIFF
--- a/unfold_extra/src/css/unfold_extra.css
+++ b/unfold_extra/src/css/unfold_extra.css
@@ -120,6 +120,11 @@ body.cms-admin-sideframe:not(.djangocms-admin-style) {
     margin-block-start: 0;
 }
 
+/* No border or shadow for fieldsets in cms plugin modal */
+body.cms-admin-modal fieldset > .form-rows {
+    @apply border-0 shadow-none;
+}
+
 /* Fix Modal displaying django parent admin navigation  */
 body.cms-admin-modal #page #main {
     @apply pt-8;
@@ -296,10 +301,6 @@ input#nav-filter {
     @apply max-w-full;
 }
 
-.cms-editor-inline-wrapper > div {
-    @apply  border border-base-200 rounded-2xl shadow-xs min-h-auto
-}
-
 .cms-editor-inline-wrapper > div + div {
     @apply mt-4;
 }
@@ -313,7 +314,7 @@ input#nav-filter {
 }
 
 textarea.CMS_Editor + div#id_body_editor.fixed .cms-toolbar[role=menubar] {
-    @apply bg-base-50 dark:bg-base-800 p-4 rounded-2xl border-0 mb-16 mt-16;
+    @apply bg-base-50 dark:bg-base-800 p-4 border-0 mb-16 mt-16;
 }
 
 textarea.CMS_Editor + div#id_body_editor.fixed .cms-toolbar[role=menubar] > * {

--- a/unfold_extra/src/css/unfold_extra.css
+++ b/unfold_extra/src/css/unfold_extra.css
@@ -120,11 +120,6 @@ body.cms-admin-sideframe:not(.djangocms-admin-style) {
     margin-block-start: 0;
 }
 
-/* No border or shadow for fieldsets in cms plugin modal */
-body.cms-admin-modal fieldset > .form-rows {
-    @apply border-0 shadow-none;
-}
-
 /* Fix Modal displaying django parent admin navigation  */
 body.cms-admin-modal #page #main {
     @apply pt-8;


### PR DESCRIPTION
- remove border from all cms modal plugin admin fieldsets
- fix djangocms_text editor toolbar to not use rounded border in order to reduce visual noise when text is scolled inside editor

## Summary by Sourcery

Remove visual borders from CMS plugin modal fieldsets and simplify the text editor toolbar styling to reduce visual noise.

Enhancements:
- Remove borders and shadows from fieldsets within CMS plugin modals for a cleaner modal appearance.
- Simplify the djangocms_text editor toolbar styling by removing rounded borders and extra container chrome to reduce visual noise when scrolling content.